### PR TITLE
remove quotes rule

### DIFF
--- a/src/eslint.js
+++ b/src/eslint.js
@@ -44,7 +44,6 @@ export default (config = {}, ...eslintConfig) => antfu(
       ],
       'perfectionist/sort-named-exports': 'error',
       'perfectionist/sort-named-imports': 'error',
-      'quotes': ['error', 'single'],
       'sort-imports': 0,
       'style/brace-style': ['error', '1tbs', { allowSingleLine: true }],
       'style/quote-props': ['error', 'consistent-as-needed'],


### PR DESCRIPTION
remove deprecated `quotes` rules since now is a stylistic rule. 